### PR TITLE
Slice with file.usedBytes instead of file.content.length/2

### DIFF
--- a/index.html
+++ b/index.html
@@ -76,10 +76,10 @@
             //console.log(file.contents.length);
             //allow user to download
             var typedArray;
-            if(file.contents.length/2 < files[0].size)
+            if(file.usedBytes < files[0].size)
             	typedArray = new Uint8Array(inputfile.contents);
            else
-           		typedArray = new Uint8Array(file.contents.slice(0,file.contents.length/2)); 
+           		typedArray = new Uint8Array(file.contents.slice(0,file.usedBytes)); 
            //console.log(typedArray);
 
 	       blob = new Blob([typedArray], {type: "application/octet-binary"});


### PR DESCRIPTION
Avoid corrupting images.